### PR TITLE
Refactored to make channel triggers more generalised

### DIFF
--- a/lib/cogs/Tournaments.py
+++ b/lib/cogs/Tournaments.py
@@ -12,18 +12,16 @@ class Tournaments(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.two_channel = config["TOURNAMENT"][self.bot.mode]["2_CHANNEL"]
-        self.threes_channel = config["TOURNAMENT"][self.bot.mode]["3_CHANNEL"]
+        self.TRIGGER_CHANNELS = {obj["ID"]: obj["TYPE"] for obj in config["TOURNAMENT"]["TRIGGER_CHANNELS"]}
         self.channels = []
         self.logger = logging.getLogger(__name__)
 
     async def cog_load(self):
-        self.logger.info(f"[COG] Loaded {self.__class__.__name__}")
-
-    @commands.Cog.listener()
-    async def on_ready(self):
-        self.category = self.bot.get_channel(config["TOURNAMENT"][self.bot.mode]["CATEGORY"])
         await self.getLostChannels()
+        for channelID in self.TRIGGER_CHANNELS:
+            if (channel := self.bot.get_channel(channelID)) is not None:
+                self.logger.info(f"[TOURNAMENTS] Listening for {channel}")
+        self.logger.info(f"[COG] Loaded {self.__class__.__name__}")
 
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
@@ -37,26 +35,25 @@ class Tournaments(commands.Cog):
             await self.deleteTournamentChannel(before.channel)
 
         #Channel creation
-        if after.channel.id == self.two_channel:
-            voice_channel = await self.createTournamentChannel(member, 2)
+        if after.channel.id in self.TRIGGER_CHANNELS:
+            voice_channel = await self.createTournamentChannel(member, self.TRIGGER_CHANNELS[after.channel.id])
             await member.move_to(voice_channel)
-        elif after.channel.id == self.threes_channel:
-            voice_channel = await self.createTournamentChannel(member, 3)
-            await member.move_to(voice_channel)
+
             
     async def getLostChannels(self):
-        for channel in self.category.channels:
-            if re.match("^RL [0-9]'s #[0-9]+$", channel.name):
-                if len(channel.members) == 0:
-                    await self.deleteTournamentChannel(channel)
-                else:
-                    self.logger.info(f"[TOURNAMENTS] Found lost channel {channel.name}")
-                    self.channels.append(channel)
+        for guild in self.bot.guilds:
+            for channel in guild.channels:
+                if re.match("^RL [0-9]'s #[0-9]+$", channel.name):
+                    if len(channel.members) == 0:
+                        await self.deleteTournamentChannel(channel)
+                    else:
+                        self.logger.info(f"[COG] Discovered old channel. Re-listening for {channel.name}")
+                        self.channels.append(channel)
 
     async def createTournamentChannel(self, member, limit):
         channels = [channel for channel in self.channels if re.match(f"^RL {limit}'s #[0-9]+$", channel.name)]
         channel_num = 1 if len(channels) == 0 else max([int(channel.name.split('#')[-1]) for channel in channels]) + 1
-        voice_channel = await member.guild.create_voice_channel(name=f"RL {limit}'s #{channel_num}", user_limit=limit, category=self.category, reason=f"{member} created a {limit}'s voice channel.")
+        voice_channel = await member.guild.create_voice_channel(name=f"RL {limit}'s #{channel_num}", user_limit=limit, category=self.bot.get_channel({v: k for k, v in self.TRIGGER_CHANNELS.items()}[limit]).category, reason=f"{member} created a {limit}'s voice channel.")
         self.channels.append(voice_channel)
         return voice_channel
             


### PR DESCRIPTION
Changes:
- All channels which are used to trigger the creation of RL channels (called Trigger Channels) can now be identified with just a channel ID as oppossed to a channel ID + category ID
- Trigger Channels are now no longer hard coded and can be dynamically added into the config.
- More logging added so we know what the bot is doing

TL:DR refactored for expandability 